### PR TITLE
hardware: FM: Add BOARD_HAVE_QCOM_FM back and prevent build errors

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifeq ($(BOARD_HAVE_QCOM_FM),true)
+
 LOCAL_PATH:= $(call my-dir)
 LOCAL_DIR_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
@@ -5,8 +7,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 
 #ifneq ($(TARGET_USES_AOSP),true)
-
-#ifeq ($(BOARD_HAVE_QCOM_FM),true)
 
 LOCAL_SRC_FILES := $(call all-java-files-under, qcom/fmradio)
 LOCAL_JNI_SHARED_LIBRARIES := libqcomfm_jni
@@ -34,9 +34,10 @@ LOCAL_PATH := $(LOCAL_DIR_PATH)
 include $(LOCAL_PATH)/fmapp2/Android.mk
 #LOCAL_PATH := $(LOCAL_DIR_PATH)
 #include $(LOCAL_PATH)/FMRecord/Android.mk
-#endif # BOARD_HAVE_QCOM_FM
 
 #endif # Not (TARGET_USES_AOSP)
 
 LOCAL_PATH := $(LOCAL_DIR_PATH)
 include $(LOCAL_PATH)/libfm_jni/Android.mk
+
+endif # BOARD_HAVE_QCOM_FM


### PR DESCRIPTION
Only build QCOM FM if BOARD_HAVE_QCOM_FM flag is true

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ib2e928b5701011fdbbf04f1c59a8fccea70e8023
