### PR TITLE
hardware: qcom: fm: Fix build for broadcom fm targets

### DIFF
--- a/libfm_jni/Android.mk
+++ b/libfm_jni/Android.mk
@@ -27,4 +27,7 @@ ifeq ($(TARGET_QCOM_NO_FM_FIRMWARE),true)
 endif
 
 LOCAL_MODULE := libfmjni
+
+ifneq ($(BOARD_HAVE_BCM_FM), true)
 include $(BUILD_SHARED_LIBRARY)
+endif


### PR DESCRIPTION
The libfmjni is already present in sony/common BCM_FM makefile which
breaks the build process when QCOM FM HAL is also present.

Sony Common:
https://github.com/sonyxperiadev/device-sony-common/blob/master/brcm_fmradio/libfmjni/Android.mk#L19

QCOM FM HAL:
https://github.com/sonyxperiadev/vendor-qcom-opensource-fm/blob/master/libfm_jni/Android.mk#L29

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: I16ab730069df87df3019ece32ae974c8296990c0
